### PR TITLE
add explicit require to Gemfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ gem install nationbuilder-rb
 Or, add this to your gemfile:
 
 ```ruby
-gem 'nationbuilder-rb'
+gem 'nationbuilder-rb', :require => 'nationbuilder'
 ```
 
 ## Creating a client


### PR DESCRIPTION
Bundler seems to assume the gem is named the same as the library.  Having different names causes load issues - this solves that.