### PR TITLE
Allow users to translate CSVs to API-ready JSON

### DIFF
--- a/lib/nationbuilder/csv_to_json_translator.rb
+++ b/lib/nationbuilder/csv_to_json_translator.rb
@@ -1,0 +1,13 @@
+require 'csv'
+
+class CSVToJSONTranslator
+  def initialize(csv)
+    @csv = csv
+  end
+
+  def translate
+    CSV.foreach(@csv, headers: :first_row) do |row|
+      yield ({ emails: [row['email1']] }).to_json
+    end
+  end
+end

--- a/spec/csv_to_json_translator_spec.rb
+++ b/spec/csv_to_json_translator_spec.rb
@@ -1,0 +1,13 @@
+require 'nationbuilder/csv_to_json_translator'
+
+describe CSVToJSONTranslator do
+  describe 'translate' do
+    let(:csv_file) { 'spec/fixtures/sample.csv' }
+
+    it 'yields each row as API-ready json' do
+      expect { |b| CSVToJSONTranslator.new(csv_file).translate(&b) }
+        .to yield_successive_args({ emails: ['1thomas@prodigy.net'] }.to_json,
+                                  { emails: ['2226helen.1403@juno.com'] }.to_json)
+    end
+  end
+end

--- a/spec/fixtures/sample.csv
+++ b/spec/fixtures/sample.csv
@@ -1,0 +1,3 @@
+shapeshifter_row_id,first_name,last_name,address__address1,address__address2,address__city,address__state,address__zip,email1,address__country,address__street_number,address__street_prefix,address__street_name,address__street_type,address__street_suffix,address__street_number_integer,address__unit_number,address__unit_number_integer,address__identity_hash
+1,Johnny,Thomas Jr,429 Balfour Dr,,Windcrest,TX,78239,1thomas@prodigy.net,,429,,Balfour,Dr,,429,,,67603c8e65c075ab1979153778060ba739e92fe0
+2,Helen,Emery,1403 Huntington Dr,,Murfreesboro,TN,37130,2226helen.1403@juno.com,,1403,,Huntington,Dr,,1403,,,8534a74a8d993ed0666e5819d86ebb5199fe69c5


### PR DESCRIPTION
@3dna/autobots @3dna/web-services 
Obviously incomplete, as I wanted to get feedback before continuing.
The purpose is to provide users the capability to translate a formatted CSV into API-ready JSON.